### PR TITLE
lang switcher position in us page

### DIFF
--- a/_sass/theme.scss
+++ b/_sass/theme.scss
@@ -75,6 +75,15 @@ p, h3 {
   }
 }
 
+@media screen and (max-width: 1024px){
+  .lang-switch-area {
+    position: relative;
+    top: 0vh;
+    right: 0;
+    padding: 0;
+  }
+
+}
 .not-found {
   display: flex;
   flex-flow: column wrap;


### PR DESCRIPTION
Lang switcher position was done on CZ page but forgot on US page. This pull request remedies this mistake :) Now the flags move down on screens below 1024px width.